### PR TITLE
feat: add "scopes" support when importing tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ dist/
 build.zip
 bin/
 out/
+
+# webstorm
+.idea

--- a/src/common/transform/tokensToVariables.spec.ts
+++ b/src/common/transform/tokensToVariables.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'vitest';
+import { getTokenScopes, isValidVariableScope } from './tokensToVariables';
+
+describe('getTokenScopes', () => {
+  test('returns scopes from standard format', () => {
+    const token = { scopes: ['ALL_SCOPES'], value: '#fff', type: 'color' };
+    expect(getTokenScopes(token)).toEqual(['ALL_SCOPES']);
+  });
+
+  test('returns undefined when no scopes key is present', () => {
+    const token = { value: '#fff', type: 'color' };
+    expect(getTokenScopes(token)).toBeUndefined();
+  });
+
+  test('returns undefined when scopes is not an array', () => {
+    const token = { scopes: 'ALL_SCOPES', value: '#fff', type: 'color' };
+    expect(getTokenScopes(token)).toBeUndefined();
+  });
+
+  test('returns empty array when scopes is an empty array', () => {
+    const token = { scopes: [], value: '#fff', type: 'color' };
+    expect(getTokenScopes(token)).toEqual([]);
+  });
+
+  test('does not read from $extensions.scopes (inconsistent with export)', () => {
+    const token = {
+      $extensions: { scopes: ['OPACITY'] },
+      value: '#fff',
+      type: 'color',
+    };
+    expect(getTokenScopes(token)).toBeUndefined();
+  });
+});
+
+describe('isValidVariableScope', () => {
+  test('returns true for valid scopes', () => {
+    expect(isValidVariableScope('ALL_SCOPES')).toBe(true);
+    expect(isValidVariableScope('OPACITY')).toBe(true);
+    expect(isValidVariableScope('FONT_SIZE')).toBe(true);
+    expect(isValidVariableScope('PARAGRAPH_INDENT')).toBe(true);
+  });
+
+  test('returns false for invalid scope strings', () => {
+    expect(isValidVariableScope('INVALID_SCOPE')).toBe(false);
+    expect(isValidVariableScope('')).toBe(false);
+    expect(isValidVariableScope('all_scopes')).toBe(false); // case-sensitive
+  });
+
+  test('returns false for non-string values', () => {
+    expect(isValidVariableScope(null)).toBe(false);
+    expect(isValidVariableScope(undefined)).toBe(false);
+    expect(isValidVariableScope(123)).toBe(false);
+  });
+});

--- a/src/common/transform/tokensToVariables.ts
+++ b/src/common/transform/tokensToVariables.ts
@@ -55,6 +55,24 @@ const getTokenDescription = (token: any): string => {
 };
 
 /**
+ * Parses DTCG or standard token format to extract the scopes
+ */
+const getTokenScopes = (token: any): VariableScope[] | undefined => {
+  // Standard format uses scopes
+  if (token.scopes !== undefined && Array.isArray(token.scopes)) {
+    return token.scopes;
+  }
+  // DTCG format uses $extensions
+  if (
+    token.$extensions?.scopes !== undefined &&
+    Array.isArray(token.$extensions.scopes)
+  ) {
+    return token.$extensions.scopes;
+  }
+  return undefined;
+};
+
+/**
  * Checks if an object is a token (has value and type)
  */
 const isToken = (obj: any): boolean => {
@@ -220,7 +238,8 @@ const extractTokens = (
       key.startsWith('$') ||
       key === 'value' ||
       key === 'type' ||
-      key === 'description'
+      key === 'description' ||
+      key === 'scopes'
     ) {
       continue; // Skip metadata keys
     }
@@ -395,6 +414,7 @@ export const tokensToVariables = async (
           try {
             const tokenType = getTokenType(token);
             const tokenDescription = getTokenDescription(token);
+            const tokenScopes = getTokenScopes(token);
 
             if (!tokenType) {
               result.errors.push(`Token at path "${path}" is missing type`);
@@ -416,14 +436,20 @@ export const tokensToVariables = async (
                 figmaType
               );
 
-              if (tokenDescription) {
-                variable.description = tokenDescription;
-              }
-
               variableMap.set(fullPath, variable);
               result.variablesCreated++;
             } else if (isExisting) {
               result.variablesUpdated++;
+            }
+
+            if (variable) {
+              if (tokenDescription) {
+                variable.description = tokenDescription;
+              }
+
+              if (tokenScopes) {
+                variable.scopes = tokenScopes;
+              }
             }
 
             // Store for second pass (value setting)

--- a/src/common/transform/tokensToVariables.ts
+++ b/src/common/transform/tokensToVariables.ts
@@ -54,20 +54,41 @@ const getTokenDescription = (token: any): string => {
   return '';
 };
 
+const VALID_VARIABLE_SCOPES: ReadonlyArray<VariableScope> = [
+  'ALL_SCOPES',
+  'TEXT_CONTENT',
+  'CORNER_RADIUS',
+  'WIDTH_HEIGHT',
+  'GAP',
+  'ALL_FILLS',
+  'FRAME_FILL',
+  'SHAPE_FILL',
+  'TEXT_FILL',
+  'STROKE_COLOR',
+  'STROKE_FLOAT',
+  'EFFECT_FLOAT',
+  'EFFECT_COLOR',
+  'OPACITY',
+  'FONT_FAMILY',
+  'FONT_STYLE',
+  'FONT_WEIGHT',
+  'FONT_SIZE',
+  'LINE_HEIGHT',
+  'LETTER_SPACING',
+  'PARAGRAPH_SPACING',
+  'PARAGRAPH_INDENT',
+];
+
+export const isValidVariableScope = (scope: any): scope is VariableScope => {
+  return VALID_VARIABLE_SCOPES.includes(scope);
+};
+
 /**
- * Parses DTCG or standard token format to extract the scopes
+ * Parses a token to extract scopes (standard format only: `scopes` key).
  */
-const getTokenScopes = (token: any): VariableScope[] | undefined => {
-  // Standard format uses scopes
+export const getTokenScopes = (token: any): string[] | undefined => {
   if (token.scopes !== undefined && Array.isArray(token.scopes)) {
     return token.scopes;
-  }
-  // DTCG format uses $extensions
-  if (
-    token.$extensions?.scopes !== undefined &&
-    Array.isArray(token.$extensions.scopes)
-  ) {
-    return token.$extensions.scopes;
   }
   return undefined;
 };
@@ -448,7 +469,18 @@ export const tokensToVariables = async (
               }
 
               if (tokenScopes) {
-                variable.scopes = tokenScopes;
+                const invalidScopes = tokenScopes.filter(
+                  (s) => !isValidVariableScope(s)
+                );
+                if (invalidScopes.length > 0) {
+                  result.errors.push(
+                    `Token at path "${path}" has invalid scopes: ${invalidScopes.join(', ')}`
+                  );
+                }
+                const validScopes = tokenScopes.filter(isValidVariableScope);
+                if (validScopes.length > 0) {
+                  variable.scopes = validScopes;
+                }
               }
             }
 


### PR DESCRIPTION
## Details

Currently, when importing tokens, `scopes` are not restored. This PR fixes this issue.

The fix has been tested with success on our own Figma design files, with scopes properly restored when exporting -> deleting variables -> importing => scopes present

If any question, I'm here to help !